### PR TITLE
fix: Reach download route on multi-language sites

### DIFF
--- a/index.php
+++ b/index.php
@@ -77,7 +77,7 @@ Kirby::plugin('bnomei/qrcode', [
                     $url = str_replace('/', '+S_L_A_S_H+', $url);
 
                     $api = implode('/', [
-                        site()->url(),
+                        kirby()->url(),
                         'plugin-qrcode',
                         urlencode(trim($url, '/')),
                         $slug,


### PR DESCRIPTION
Right now, `site()->url()` is used to generate the download endpoint url. This does fail on multi-language sites, if the url contains a language slug. 

I propose to use `kirby->url()` instead, to be sure to reach the download route on any installation.